### PR TITLE
Update azure-pipelines.yml for Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,34 +1,39 @@
-# ASP.NET Core (.NET Framework)
-# Build and test ASP.NET Core projects targeting the full .NET Framework.
-# Add steps that publish symbols, save build artifacts, and more:
-# https://docs.microsoft.com/azure/devops/pipelines/languages/dotnet-core
-
-trigger:
-- main
-
-pool:
-  vmImage: 'windows-latest'
-
-variables:
-  solution: '**/*.sln'
-  buildPlatform: 'Any CPU'
-  buildConfiguration: 'Release'
-
-steps:
-- task: NuGetToolInstaller@1
-
-- task: NuGetCommand@2
+## Xcode v5
+# Build, test, or archive an Xcode workspace on macOS. Optionally package an app.
+- task: Xcode@5
   inputs:
-    restoreSolution: '$(solution)'
-
-- task: VSBuild@1
-  inputs:
-    solution: '$(solution)'
-    msbuildArgs: '/p:DeployOnBuild=true /p:WebPublishMethod=Package /p:PackageAsSingleFile=true /p:SkipInvalidConfigurations=true /p:DesktopBuildPackageLocation="$(build.artifactStagingDirectory)\WebApp.zip" /p:DeployIisAppPath="Default Web Site"'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
-
-- task: VSTest@2
-  inputs:
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
+    actions: 'build' # string. Required. Actions. Default: build.
+    #configuration: '$(Configuration)' # string. Configuration. Default: $(Configuration).
+    #sdk: '$(SDK)' # string. SDK. Default: $(SDK).
+    #xcWorkspacePath: '**/*.xcodeproj/project.xcworkspace' # string. Workspace or project path. Default: **/*.xcodeproj/project.xcworkspace.
+    #scheme: # string. Scheme. 
+    #xcodeVersion: 'default' # '8' | '9' | '10' | '11' | '12' | '13' | 'default' | 'specifyPath'. Xcode version. Default: default.
+    #xcodeDeveloperDir: # string. Optional. Use when xcodeVersion == specifyPath. Xcode developer path. 
+  # Package options
+    #packageApp: false # boolean. Create app package. Default: false.
+    #archivePath: # string. Optional. Use when packageApp == true. Archive path. 
+    #exportPath: 'output/$(SDK)/$(Configuration)' # string. Optional. Use when packageApp == true. Export path. Default: output/$(SDK)/$(Configuration).
+    #exportOptions: 'auto' # 'auto' | 'plist' | 'specify'. Optional. Use when packageApp == true. Export options. Default: auto.
+    #exportMethod: 'development' # string. Required when exportOptions == specify. Export method. Default: development.
+    #exportTeamId: # string. Optional. Use when exportOptions == specify. Team ID. 
+    #exportOptionsPlist: # string. Required when exportOptions == plist. Export options plist. 
+    #exportArgs: # string. Optional. Use when packageApp == true. Export arguments. 
+  # Signing & provisioning
+    #signingOption: 'nosign' # 'nosign' | 'default' | 'manual' | 'auto'. Signing style. Default: nosign.
+    #signingIdentity: # string. Optional. Use when signingOption = manual. Signing identity. 
+    #provisioningProfileUuid: # string. Optional. Use when signingOption = manual. Provisioning profile UUID. 
+    #provisioningProfileName: # string. Optional. Use when signingOption = manual. Provisioning profile name. 
+    #teamId: # string. Optional. Use when signingOption = auto. Team ID. 
+  # Devices & simulators
+    #destinationPlatformOption: 'default' # 'default' | 'iOS' | 'tvOS' | 'macOS' | 'custom'. Destination platform. Default: default.
+    #destinationPlatform: # string. Optional. Use when destinationPlatformOption == custom. Custom destination platform. 
+    #destinationTypeOption: 'simulators' # 'simulators' | 'devices'. Optional. Use when destinationPlatformOption != default && destinationPlatformOption != macOS. Destination type. Default: simulators.
+    #destinationSimulators: # string. Optional. Use when destinationPlatformOption != default && destinationPlatformOption != macOS && destinationTypeOption == simulators. Simulator. 
+    #destinationDevices: # string. Optional. Use when destinationPlatformOption != default && destinationPlatformOption != macOS && destinationTypeOption == devices. Device. 
+  # Advanced
+    #args: # string. Arguments. 
+    #workingDirectory: # string. Alias: cwd. Working directory. 
+    #useXcpretty: true # boolean. Use xcpretty. Default: true.
+    #xcprettyArgs: # string. Optional. Use when useXcpretty == true. Xcpretty arguments. 
+    #publishJUnitResults: false # boolean. Publish test results to Azure Pipelines. Default: false.
+    #testRunTitle: # string. Optional. Use when publishJUnitResults == true. Test run title.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,4 +1,34 @@
-## Xcode v5
+// This example demonstrates the Version.Revision,
+// MajorRevision, and MinorRevision properties.
+using System;
+
+class Sample 
+{
+    public static void Main() 
+    {
+
+    string fmtStd = "Standard version:\n" +
+                    "  major.minor.build.revision = {0}.{1}.{2}.{3}";
+    string fmtInt = "Interim version:\n" +
+                    "  major.minor.build.majRev/minRev = {0}.{1}.{2}.{3}/{4}";
+
+    Version std = new Version(2, 4, 1128, 2);
+    Version interim = new Version(2, 4, 1128, (100 << 16) + 2);
+
+    Console.WriteLine(fmtStd, std.Major, std.Minor, std.Build, std.Revision);
+    Console.WriteLine(fmtInt, interim.Major, interim.Minor, interim.Build, 
+                              interim.MajorRevision, interim.MinorRevision);
+    }
+}
+/*
+This code example produces the following results:
+
+Standard version:
+  major.minor.build.revision = 2.4.1128.2
+Interim version:
+  major.minor.build.majRev/minRev = 2.4.1128.100/2
+
+*/## Xcode v5
 # Build, test, or archive an Xcode workspace on macOS. Optionally package an app.
 - task: Xcode@5
   inputs:


### PR DESCRIPTION
# Xcode v5
# Build, test, or archive an Xcode workspace on macOS. Optionally package an app.
- task: Xcode@5
  inputs:
    actions: 'build' # string. Required. Actions. Default: build.
    #configuration: '$(Configuration)' # string. Configuration. Default: $(Configuration).
    #sdk: '$(SDK)' # string. SDK. Default: $(SDK).
    #xcWorkspacePath: '**/*.xcodeproj/project.xcworkspace' # string. Workspace or project path. Default: **/*.xcodeproj/project.xcworkspace.
    #scheme: # string. Scheme. 
    #xcodeVersion: 'default' # '8' | '9' | '10' | '11' | '12' | '13' | 'default' | 'specifyPath'. Xcode version. Default: default.
    #xcodeDeveloperDir: # string. Optional. Use when xcodeVersion == specifyPath. Xcode developer path. 
  # Package options
    #packageApp: false # boolean. Create app package. Default: false.
    #archivePath: # string. Optional. Use when packageApp == true. Archive path. 
    #exportPath: 'output/$(SDK)/$(Configuration)' # string. Optional. Use when packageApp == true. Export path. Default: output/$(SDK)/$(Configuration).
    #exportOptions: 'auto' # 'auto' | 'plist' | 'specify'. Optional. Use when packageApp == true. Export options. Default: auto.
    #exportMethod: 'development' # string. Required when exportOptions == specify. Export method. Default: development.
    #exportTeamId: # string. Optional. Use when exportOptions == specify. Team ID. 
    #exportOptionsPlist: # string. Required when exportOptions == plist. Export options plist. 
    #exportArgs: # string. Optional. Use when packageApp == true. Export arguments. 
  # Signing & provisioning
    #signingOption: 'nosign' # 'nosign' | 'default' | 'manual' | 'auto'. Signing style. Default: nosign.
    #signingIdentity: # string. Optional. Use when signingOption = manual. Signing identity. 
    #provisioningProfileUuid: # string. Optional. Use when signingOption = manual. Provisioning profile UUID. 
    #provisioningProfileName: # string. Optional. Use when signingOption = manual. Provisioning profile name. 
    #teamId: # string. Optional. Use when signingOption = auto. Team ID. 
  # Devices & simulators
    #destinationPlatformOption: 'default' # 'default' | 'iOS' | 'tvOS' | 'macOS' | 'custom'. Destination platform. Default: default.
    #destinationPlatform: # string. Optional. Use when destinationPlatformOption == custom. Custom destination platform. 
    #destinationTypeOption: 'simulators' # 'simulators' | 'devices'. Optional. Use when destinationPlatformOption != default && destinationPlatformOption != macOS. Destination type. Default: simulators.
    #destinationSimulators: # string. Optional. Use when destinationPlatformOption != default && destinationPlatformOption != macOS && destinationTypeOption == simulators. Simulator. 
    #destinationDevices: # string. Optional. Use when destinationPlatformOption != default && destinationPlatformOption != macOS && destinationTypeOption == devices. Device. 
  # Advanced
    #args: # string. Arguments. 
    #workingDirectory: # string. Alias: cwd. Working directory. 
    #useXcpretty: true # boolean. Use xcpretty. Default: true.
    #xcprettyArgs: # string. Optional. Use when useXcpretty == true. Xcpretty arguments. 
    #publishJUnitResults: false # boolean. Publish test results to Azure Pipelines. Default: false.
    #testRunTitle: # string. Optional. Use when publishJUnitResults == true. Test run title.